### PR TITLE
Update transaction_retry dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+### Unreleased
+
+* Update dependency activerecord >= 5.1
+* Update dependency ruby 2.2.2
+* Upgrade dependency transaction_isolation to 1.0.5
+* Adapt gemspec info
+* Forked gem from [transaction_retry 1.0.3](https://github.com/qertoip/transaction_retry)

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gemspec
 
 group :test do
   # Use the gem instead of a dated version bundled with Ruby
-  gem 'minitest', '2.8.1'
-  
+  gem 'minitest'
+
   gem 'simplecov', :require => false
 
   gem 'mysql2'

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This gem was initially developed for and successfully works in production at [Ko
 
 ## Requirements
 
- * ruby 2.6.2+
+ * ruby 2.2.2+
  * activerecord 5.1+
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL, and SQLite.
 
+This is a forked project from [transaction_retry](https://github.com/qertoip/transaction_retry)
+
 ## Example
 
 The gem works automatically by rescuing ActiveRecord::TransactionIsolationConflict and retrying the transaction.
@@ -10,7 +12,7 @@ The gem works automatically by rescuing ActiveRecord::TransactionIsolationConfli
 
 Add this to your Gemfile:
 
-    gem 'transaction_retry'
+    gem 'transaction_retry', git: 'https://github.com/optimalworkshop/transaction_retry.git'
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This gem was initially developed for and successfully works in production at [Ko
 ## Requirements
 
  * ruby 2.6.2+
- * activerecord 5.2+
+ * activerecord 5.1+
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This gem was initially developed for and successfully works in production at [Ko
 
 ## Requirements
 
- * ruby 1.9.2
- * activerecord 3.0.11+
+ * ruby 2.6.2+
+ * activerecord 5.2+
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,13 @@ This gem was initially developed for and successfully works in production at [Ko
 
 Run tests on the selected database (mysql2 by default):
 
-    db=mysql2 bundle exec rake test
-    db=postgresql bundle exec rake test
+    db=mysql2 DB_USERNAME=<db user> DB_PASSWORD=<db password> bundle exec rake test
+    db=postgresql DB_USERNAME=<db user> DB_PASSWORD=<db password> bundle exec rake test
     db=sqlite3 bundle exec rake test
 
 Run tests on all supported databases:
 
     ./tests
-
-Database configuration is hardcoded in test/db/db.rb; feel free to improve this and submit a pull request.
 
 ## How intrusive is this gem?
 

--- a/test/db/db.rb
+++ b/test/db/db.rb
@@ -8,20 +8,20 @@ module TransactionRetry
         ::ActiveRecord::Base.establish_connection(
           :adapter => "mysql2",
           :database => "transaction_retry_test",
-          :user => 'root',
-          :password => ''
+          :username => ENV['DB_USERNAME'],
+          :password => ENV['DB_PASSWORD']
         )
       end
-      
+
       def self.connect_to_postgresql
         ::ActiveRecord::Base.establish_connection(
           :adapter => "postgresql",
           :database => "transaction_retry_test",
-          :user => 'qertoip',
-          :password => 'test123'
+          :user => ENV['DB_USERNAME'],
+          :password => ENV['DB_PASSWORD']
         )
       end
-      
+
       def self.connect_to_sqlite3
         ActiveRecord::Base.establish_connection(
           :adapter => "sqlite3",

--- a/test/integration/active_record/base/transaction_with_retry_test.rb
+++ b/test/integration/active_record/base/transaction_with_retry_test.rb
@@ -16,7 +16,7 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
     TransactionRetry.wait_times = @original_wait_times
     QueuedJob.delete_all
   end
-  
+
   def test_does_not_break_transaction
     ActiveRecord::Base.transaction do
       QueuedJob.create!( :job => 'is fun!' )
@@ -41,12 +41,12 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
       if first_run
         first_run = false
         message = "Deadlock found when trying to get lock"
-        raise ActiveRecord::TransactionIsolationConflict.new( ActiveRecord::StatementInvalid.new( message ), message )
+        raise ActiveRecord::TransactionIsolationConflict.new(message)
       end
       QueuedJob.create!( :job => 'is cool!' )
     end
     assert_equal( 1, QueuedJob.count )
-    
+
     QueuedJob.first.destroy
   end
 
@@ -78,7 +78,7 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
       QueuedJob.create!( :job => 'is cool!' )
     end
     assert_equal( 1, QueuedJob.count )
-    
+
     QueuedJob.first.destroy
   end
 
@@ -90,10 +90,10 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
       ActiveRecord::Base.transaction do
         run += 1
         message = "Deadlock found when trying to get lock"
-        raise ActiveRecord::TransactionIsolationConflict.new( ActiveRecord::StatementInvalid.new( message ), message )
+        raise ActiveRecord::TransactionIsolationConflict.new(message)
       end
     end
-    
+
     assert_equal( 2, run )  # normal run + one retry
 
     TransactionRetry.max_retries = 3
@@ -104,10 +104,10 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
       ActiveRecord::Base.transaction(max_retries: 1) do
         run += 1
         message = "Deadlock found when trying to get lock"
-        raise ActiveRecord::TransactionIsolationConflict.new( ActiveRecord::StatementInvalid.new( message ), message )
+        raise ActiveRecord::TransactionIsolationConflict.new(message)
       end
     end
-    
+
     assert_equal( 2, run )  # normal run + one retry
   end
 
@@ -121,15 +121,14 @@ class TransactionWithRetryTest < MiniTest::Unit::TestCase
           if first_try
             first_try = false
             message = "Deadlock found when trying to get lock"
-            raise ActiveRecord::TransactionIsolationConflict.new( ActiveRecord::StatementInvalid.new( message ), message )
+            raise ActiveRecord::TransactionIsolationConflict.new(message)
           end
           QueuedJob.create!( :job => 'is cool!' )
         end
       end
-      
+
     end
-      
+
     assert_equal( 0, QueuedJob.count )
   end
-
 end

--- a/transaction_retry.gemspec
+++ b/transaction_retry.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "activerecord", ">= 5.2"
+  s.add_runtime_dependency "activerecord", ">= 5.1"
   s.add_runtime_dependency "transaction_isolation", ">= 1.0.5"
 end

--- a/transaction_retry.gemspec
+++ b/transaction_retry.gemspec
@@ -5,18 +5,18 @@ require "transaction_retry/version"
 Gem::Specification.new do |s|
   s.name        = "transaction_retry"
   s.version     = TransactionRetry::VERSION
-  s.authors     = ["Piotr 'Qertoip' Włodarek"]
-  s.email       = ["qertoip@gmail.com"]
-  s.homepage    = "https://github.com/qertoip/transaction_retry"
+  s.authors     = ["Optimal Workshop"]
+  s.email       = []
+  s.homepage    = "https://github.com/optimalworkshop/transaction_retry"
   s.summary     = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite.}
   s.description = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite (as long as you are using new drivers mysql2, pg, sqlite3).}
-  s.required_ruby_version = '>= 1.9.2'
-  
+  s.required_ruby_version = '>= 2.6.2'
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "activerecord", ">= 3.0.11"
-  s.add_runtime_dependency "transaction_isolation", ">= 1.0.2"
+  s.add_runtime_dependency "activerecord", ">= 5.2"
+  s.add_runtime_dependency "transaction_isolation", ">= 1.0.5"
 end

--- a/transaction_retry.gemspec
+++ b/transaction_retry.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/optimalworkshop/transaction_retry"
   s.summary     = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite.}
   s.description = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite (as long as you are using new drivers mysql2, pg, sqlite3).}
-  s.required_ruby_version = '>= 2.6.2'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Adapted forked gem to OW organisation and updated gem dependencies:

* Support activerecord >= 5.1
* Support ruby 2.6.2
* Upgrade dependency version of transaction_isolation to 1.0.5 and adapt affected code
* Upgrade minitest
* Adapt gemspec info