### PR TITLE
Allow configuring global custom errors to retry on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Add `TransactionRetry.retry_on` configuration option to include more Errors to retry on
 * Update dependency activerecord >= 5.1
 * Update dependency ruby 2.2.2
 * Upgrade dependency transaction_isolation to 1.0.5

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can optionally configure transaction_retry gem in your config/initializers/t
 
     TransactionRetry.max_retries = 3
     TransactionRetry.wait_times = [0, 1, 2, 4, 8, 16, 32]   # seconds to sleep after retry n
+    TransactionRetry.retry_on = CustomErrorClass # To add another error class to retry on (ActiveRecord::TransactionIsolationConflict always included)
+  or
+    TransactionRetry.retry_on = [<custom error classes>]
+
 
 ## Features
 

--- a/lib/transaction_retry.rb
+++ b/lib/transaction_retry.rb
@@ -1,6 +1,5 @@
 require "active_record"
 require "transaction_isolation"
-
 require_relative "transaction_retry/version"
 
 module TransactionRetry
@@ -20,6 +19,14 @@ module TransactionRetry
         TransactionRetry.apply_activerecord_patch
       end
     end
+  end
+
+  def self.retry_on=(error_classes)
+    @@retry_on = Array(error_classes)
+  end
+
+  def self.retry_on
+    @@retry_on ||= []
   end
 
   def self.max_retries

--- a/lib/transaction_retry/active_record/base.rb
+++ b/lib/transaction_retry/active_record/base.rb
@@ -13,9 +13,9 @@ module TransactionRetry
           end
         end
       end
-      
+
       module ClassMethods
-        
+
         def transaction_with_retry(*objects, &block)
           retry_count = 0
 
@@ -25,7 +25,7 @@ module TransactionRetry
             {}
           end
 
-          retry_on = opts.delete(:retry_on)
+          retry_on = opts.delete(:retry_on) || TransactionRetry.retry_on
           max_retries = opts.delete(:max_retries) || TransactionRetry.max_retries
 
           begin
@@ -33,7 +33,7 @@ module TransactionRetry
           rescue *[::ActiveRecord::TransactionIsolationConflict, *retry_on]
             raise if retry_count >= max_retries
             raise if tr_in_nested_transaction?
-            
+
             retry_count += 1
             postfix = { 1 => 'st', 2 => 'nd', 3 => 'rd' }[retry_count] || 'th'
 
@@ -49,7 +49,7 @@ module TransactionRetry
             retry
           end
         end
-        
+
         private
 
           # Sleep 0, 1, 2, 4, ... seconds up to the TransactionRetry.max_retries.
@@ -66,7 +66,7 @@ module TransactionRetry
 
             sleep( seconds ) if seconds > 0
           end
-        
+
           # Returns true if we are in the nested transaction (the one with :requires_new => true).
           # Returns false otherwise.
           # An ugly tr_ prefix is used to minimize the risk of method clash in the future.


### PR DESCRIPTION
Add option to configure a module `retry_on` property to add more error classes to retry on when raised. _ActiveRecord::TransactionIsolationConflict_ is always caught and handled.