### PR TITLE
Add the before_retry option to configure a custom lambda block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Add `TransactionRetry.before_retry` configuration option to run Proc before transaction retry
 * Add `TransactionRetry.retry_on` configuration option to include more Errors to retry on
 * Update dependency activerecord >= 5.1
 * Update dependency ruby 2.2.2

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can optionally configure transaction_retry gem in your config/initializers/t
     TransactionRetry.retry_on = CustomErrorClass # To add another error class to retry on (ActiveRecord::TransactionIsolationConflict always included)
   or
     TransactionRetry.retry_on = [<custom error classes>]
-
+    TransactionRetry.before_retry = ->(retry_num, error) { ... }
 
 ## Features
 
@@ -62,6 +62,7 @@ You can optionally configure transaction_retry gem in your config/initializers/t
  * Logs every retry as a warning.
  * Intentionally does not retry nested transactions.
  * Configurable number of retries and sleep time between them.
+ * Configure a custom hook to run before every retry.
  * Use it in your Rails application or a standalone ActiveRecord-based project.
 
 ## Testimonials

--- a/lib/transaction_retry.rb
+++ b/lib/transaction_retry.rb
@@ -21,6 +21,14 @@ module TransactionRetry
     end
   end
 
+  def self.before_retry=(lambda_block)
+    @@before_retry = lambda_block
+  end
+
+  def self.before_retry
+    @@before_retry ||= nil
+  end
+
   def self.retry_on=(error_classes)
     @@retry_on = Array(error_classes)
   end


### PR DESCRIPTION
Add the before_retry option to configure a custom lambda block before each retry with the retry number and the error as arguments.